### PR TITLE
Data type "string" for linked_account_id

### DIFF
--- a/views/aws_billing.view.lkml
+++ b/views/aws_billing.view.lkml
@@ -155,7 +155,7 @@ view: aws_billing {
 
     dimension: linked_account_id {
       group_label: "IDs"
-      type: number
+      type: string
       sql: ${TABLE}.line_item_usage_account_id ;;
     }
     dimension: operation {


### PR DESCRIPTION
Glue table specifies "string" when using the provided sql code generated alongside parquet files by the AWS usage and cost report function.

![image](https://user-images.githubusercontent.com/11086958/143908112-47d2026a-e0e8-418b-a2fc-744c1a72b339.png)
